### PR TITLE
Toggle All link on its own line

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -18,6 +18,11 @@ a {
     color: #88f;
 }
 
+.expand {
+	display: block;
+	margin-bottom: 5px;
+}
+
 .output, .input {
     border: 1px solid #aaa;
     background: #fff;


### PR DESCRIPTION
This is a request just to change the display of the Toggle All link that appears when krumo debug data is displayed. Currently, the first line of text that is echoed along with a krumo call will be displayed right along side the Toggle All link:

![ToggleAllNoBlock](https://f.cloud.github.com/assets/4011193/432260/5a48b4c6-ae9f-11e2-914f-dd2cfb492c80.PNG)

But giving `.expand` block display and a little bottom margin provides some nicer spacing:

![ToggleAllBlock](https://f.cloud.github.com/assets/4011193/432306/6ee5a2b2-aea0-11e2-888e-97200177693a.PNG)

Also included in this branch are commits from [Pull Request #8](https://github.com/Seldaek/php-console/pull/8) regarding checking for HTTP auth since I neglected to put those in a separate branch, but of course I hope those changes are still being considered.

Hey, I just wanna say again that I appreciate all the helpful feedback and letting me participate in this excellent project. So yes, for your consideration...
