### PR TITLE
Give editor focus and go to line 2

### DIFF
--- a/php-console.js
+++ b/php-console.js
@@ -85,6 +85,12 @@
 
         editor = ace.edit(options.editor);
 
+        // give focus
+        editor.focus();
+        
+        // move cursor to line 2
+        editor.gotoLine(2,0);
+
         // set mode
         PhpMode = require("ace/mode/php").Mode;
         editor.getSession().setMode(new PhpMode());


### PR DESCRIPTION
This pull request is just for giving the ACE editor focus and moving the cursor to line two when the page loads
![focus](https://f.cloud.github.com/assets/4011193/457209/eadbadd6-b38b-11e2-8fc5-fea3bf75e3d9.png)
