### PR TITLE
added a ajax error handler.

### DIFF
--- a/php-console.js
+++ b/php-console.js
@@ -75,6 +75,11 @@
             refreshKrumoState();
         });
     };
+    
+    handleAjaxError = function(event, jqxhr, settings, exception) {
+        $('div.output').html("<em>Error occured while posting your code.</em>");
+        refreshKrumoState();
+    };
 
     initializeAce = function() {
         var PhpMode, code;
@@ -120,6 +125,7 @@
 
         $(function() {
             $(document).ready(initializeAce);
+            $(document).ajaxError(handleAjaxError);
 
             $('form').submit(handleSubmit);
         });


### PR DESCRIPTION
sometimes errors occur on the client side. because of the
ajax.complete() callback is not fired the loading indicator does not
disappear and the ui feels like the request runs endless, even if it
already terminated with an error.
