### PR TITLE
Allow access if HTTP authorization took place

### DIFF
--- a/index.php
+++ b/index.php
@@ -20,7 +20,20 @@ $options = array(
  *
  * Source on Github http://github.com/Seldaek/php-console
  */
-if (!in_array($_SERVER['REMOTE_ADDR'], $options['ip_whitelist'], true)) {
+ 
+ /* 
+php-console will only load if it is either launched from localhost or in a directory
+that requires HTTP authentication.
+*/
+$httpAuth = false; // Assume no authorization
+if(!empty($_SERVER['REMOTE_USER'])){
+	// The remote user is authorized
+	$httpAuth = true;
+} else if(function_exists('apache_request_headers') &&
+			array_key_exists('Authorization', apache_request_headers())){
+	// The Apache Web Server acknowledges authorization
+	$httpAuth = true;
+} else if (!in_array($_SERVER['REMOTE_ADDR'], $options['ip_whitelist'], true)) {
     header('HTTP/1.1 401 Access unauthorized');
     die('ERR/401 Go Away');
 }


### PR DESCRIPTION
Wow... I'm not clear on why this request involves 14 previous commits since last April. I only meant to request a single change to a single file. Maybe I need to rebase at some point...?

Check out the [previous discussion](https://github.com/Seldaek/php-console/pull/8).

Anyway, I think this would be a nice feature to have so you could securely use this tool on a live web server. From what I understand, if either `$_SERVER['REMOTE_USER']` is not empty or the key 'Authorization' exists in the array returned by `apache_request_headers()`, that should indicate successful HTTP authorization. Although it's possible that the server authenticated the user in a way that those values would not detect. Also, there could still be a way to spoof those values, but no method immediately comes to mind. What do you say?
