### PR TITLE
Load page if HTTP authorized

### DIFF
--- a/index.php
+++ b/index.php
@@ -19,8 +19,19 @@ $options = array(
  * See the LICENSE file for details
  *
  * Source on Github http://github.com/Seldaek/php-console
- */
-if (!in_array($_SERVER['REMOTE_ADDR'], $options['ip_whitelist'], true)) {
+  
+php-console will only load if it is either launched from localhost or in a directory
+that requires HTTP authorization.
+*/
+$httpAuth = false; // Assume no authorization
+if(!empty($_SERVER['REMOTE_USER'])){
+	// The remote user is authorized
+	$httpAuth = true;
+} else if(function_exists('apache_request_headers') &&
+			array_key_exists('Authorization', apache_request_headers())){
+	// The Apache Web Server acknowledges authorization
+	$httpAuth = true;
+} else if (!in_array($_SERVER['REMOTE_ADDR'], $options['ip_whitelist'], true)) {
     header('HTTP/1.1 401 Access unauthorized');
     die('ERR/401 Go Away');
 }


### PR DESCRIPTION
Whew! Thanks to the [awesome people at stackoverflow](http://stackoverflow.com/questions/6102297/how-do-i-clean-up-my-github-fork-so-i-can-make-clean-pull-requests), I now understand that my best bet is to rebase my local repository and then forcibly push that to my fork of this project whenever I wish to update it to the status of the main one.

Sorry for all the unnecessary activity up here. But now I hope you'll take a moment to check out this very clean pull request and the [original discussion](https://github.com/Seldaek/php-console/pull/8) for it. It will allow the page to load only if it was either launched from localhost or HTTP authorization was successful.
