### PR TITLE
initial sensiolabs/melody integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 vendor
 config.php
+composer.lock

--- a/README.mdown
+++ b/README.mdown
@@ -48,6 +48,7 @@ Changelog
 ---------
 
 - 1.5.0-dev
+  - Added melody-script integration. requires a composer binary within the systems/webservers PATH env variable.
   - Updated bundled ACE editor to 1.1.8
   - Layout is now flex-css based
   - Added a new `bootstrap` option to be include before source evaluation

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
         }
     ],
     "require": {
-        "php": ">=5.2.0"
+        "php": ">=5.2.0",
+        "sensiolabs/melody": "@dev"
     },
     "extra": {
         "branch-alias": {

--- a/lib/MelodyPlugin.php
+++ b/lib/MelodyPlugin.php
@@ -1,0 +1,59 @@
+<?php
+
+use SensioLabs\Melody\Melody;
+use SensioLabs\Melody\Configuration\RunConfiguration;
+use Symfony\Component\Process\Process;
+use SensioLabs\Melody\Resource\ResourceParser;
+
+/**
+ * Class which integrates melody scripts into the php-console.
+ *
+ * @author mstaab
+ * @see https://github.com/sensiolabs/melody
+ */
+class MelodyPlugin {
+    public function isMelodyScript($source) {
+        return preg_match(ResourceParser::MELODY_PATTERN, $source);
+    }
+
+    public function isScriptingSupported() {
+        // the melody lib is bundled with the console, so the only additional requirement is a composer CLI
+        exec('which composer', $out, $ret);
+        return $ret === 0;
+    }
+
+    public function runScript($__source_code, $__bootstrap_file)
+    {
+        $tmpDir = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'melody-composer';
+
+        // make sure the melody subprocess has a composer home,
+        // which is not the case when running from webcontext
+        $_ENV['COMPOSER_HOME'] = $tmpDir;
+
+        $melody = new Melody();
+        $configuration = new RunConfiguration(/*true, true*/);
+        $executor = function (Process $process, $verbose)
+        {
+            $callback = function ($type, $text)
+            {
+                // we only have one output channel to the browser, just echo "all the things"
+                echo $text;
+            };
+            $process->run($callback);
+        };
+
+        //TODO missing $__bootstrap_file support
+        /*
+        if ($__bootstrap_file) {
+            require $__bootstrap_file;
+        }
+        */
+
+        $tmpFile = tempnam($tmpDir, '_script');
+        register_shutdown_function(function() use ($tmpFile) {
+            @unlink($tmpFile);
+        });
+        file_put_contents($tmpFile, $__source_code);
+        $melody->run($tmpFile, array(), $configuration, $executor);
+    }
+}


### PR DESCRIPTION
This PR integrates melody-scripts into the php-console.

This means you can run melody scripts directly from your webbrowser.
the melody integration makes sure all required composer dependencies are downloaded and available to the code within the console.

On the first run (when dependencies are present which are not yet resolved) the php-console output panel will show what composer is doing in the background.
![melody-console-initial](https://cloud.githubusercontent.com/assets/120441/5901380/5b399230-a572-11e4-9047-bb546c7eacfc.png)

On any subsequent run (or run which only used already downloaded dependencies) the output looks like we are used to:
![melody-console-run](https://cloud.githubusercontent.com/assets/120441/5901394/85309df4-a572-11e4-94a2-6757717b0441.png)

//cc @lyrixx @jeremy-derusse