### PR TITLE
Remove depricated and unused code

### DIFF
--- a/index.php
+++ b/index.php
@@ -73,10 +73,6 @@ function runCode($__source_code, $__bootstrap_file)
 }
 
 if (isset($_POST['code'])) {
-    if (get_magic_quotes_gpc()) {
-        $code = stripslashes($code);
-    }
-
     $code = $_POST['code'];
 
     // if there's only one line wrap it into a krumo() call


### PR DESCRIPTION
The function `get_magic_quotes_gpc` is deprecated in PHP 7.4. As the $code variable is directly overwritten, the deprecated function can be safely removed, IMO.